### PR TITLE
Allow empty plugin options.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,12 +91,11 @@ export default function ({ Plugin, types: t }) {
       return;
     }
     const pluginOptions = file.opts.extra['react-transform'];
-    if (!Array.isArray(pluginOptions) || pluginOptions.length === 0) {
+    if (!Array.isArray(pluginOptions)) {
       throw new Error(
         'babel-plugin-react-transform requires that you specify ' +
         'extras["react-transform"] in .babelrc ' +
-        'or in your Babel Node API call options, and that it is an array ' +
-        'with more than zero elements.'
+        'or in your Babel Node API call options, and that it is an array.'
       );
     }
     return pluginOptions;


### PR DESCRIPTION
This allows for a conditional `extra` parameter to not throw an error when using babel programatically (i.e. not via `.babelrc`). For example:

```javascript
extra: {
  'react-transform': env !== 'production' ? [{
    target: 'react-transform-webpack-hmr',
    imports: [ 'react' ],
    locals: [ 'module' ]
  }] : [ ] // This would otherwise balk.
}
```

Arguably one could simply check if there are no `extra` values for the plugin and simply not load it.