### PR TITLE
Allow module loader(s) to resolve paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,5 @@
     "reactjs",
     "components"
   ],
-  "dependencies": {
-    "path-parse": "^1.0.5"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-react-transform",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Babel plugin to instrument React components with custom transforms",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
All I've done with this PR is remove the manual path resolving.  Why'd I do this?  Because it allows client-side module loaders like `jspm`+`systemjs` to work (i.e., modules are within `jspm_packages`, not `node_modules`) and it removes the dependencies on `path` and `parse-path`.  IMHO, it isn't the plugin's job to resolve paths.