### PR TITLE
[README] rename babel-plugin-transform-react-display-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ It must be an object with a `transforms` property being an array of the transfor
     // or is equal to "development"
     "development": {
       "plugins": [
-        // Include babel-plugin-react-display-name if you’re
+        // Include babel-plugin-transform-react-display-name if you’re
         // using React.createClass() *before* react-transform:
-        // "react-display-name",
+        // "transform-react-display-name",
         "react-transform"
       ],
       "extra": {
@@ -85,7 +85,7 @@ It must be an object with a `transforms` property being an array of the transfor
 
 As you can see each transform, apart from the `transform` field where you write it name, also has `imports` and `locals` fields. You should consult the docs of each individual transform to learn which `imports` and `locals` it might need, and how it uses them. You probably already guessed that this is just a way to inject local variables (like `module`) or dependencies (like `react`) into the transforms that need them.
 
-Note that when using `React.createClass()` and allowing `babel` to extract the `displayName` property you must ensure that [babel-plugin-react-display-name](https://github.com/babel/babel/tree/development/packages/babel-plugin-react-display-name) is included before `react-transform`. See [this github issue](https://github.com/gaearon/babel-plugin-react-transform/issues/19) for more details.
+Note that when using `React.createClass()` and allowing `babel` to extract the `displayName` property you must ensure that [babel-plugin-transform-react-display-name](https://github.com/babel/babel/tree/development/packages/babel-plugin-transform-react-display-name) is included before `react-transform`. See [this github issue](https://github.com/gaearon/babel-plugin-react-transform/issues/19) for more details.
 
 You may optionally specify an array of strings called `factoryMethods` if you want the plugin to look for components created with a factory method other than `React.createClass`. Note that you don’t have to do anything special to look for ES6 components—`factoryMethods` is only relevant if you use factory methods akin to `React.createClass`.
 


### PR DESCRIPTION
Name changed.

**Wait** `npm publish` of https://www.npmjs.com/package/babel-plugin-transform-react-display-name before merging. (https://github.com/babel/babel/issues/2476)