### PR TITLE
Add component line number to component record if available.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,12 @@ export default function ({ Plugin, types: t }) {
         t.literal(displayName)
       ));
     }
+    if (node.loc !== undefined && node.loc.start !== undefined) {
+      props.push(t.property('init',
+        t.identifier('line'),
+        t.literal(node.loc.start.line)
+      ));
+    }
     if (state[depthKey] > 0) {
       props.push(t.property('init',
         t.identifier('isInFunction'),


### PR DESCRIPTION
For introspection purposes, we've found it useful for a transformer to know the line number of any React component definition. This pull request adds a line number to each component record.