### PR TITLE
Displaynames with invalid JSON characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ export default function({ types: t, template }) {
       path.node[VISITED_KEY] = true;
 
       // `foo({ displayName: 'NAME' });` => 'NAME'
-      const componentName = getDisplayName(path.node);
+      const componentName = getDisplayName(path.node).replace(/[\.-]/g, '_'); //Make sure all non-JSON accepted characters are replaced!
       const componentId = componentName || path.scope.generateUid('component');
       const isInFunction = hasParentFunction(path);
 

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,8 @@ export default function({ types: t, template }) {
       path.node[VISITED_KEY] = true;
 
       // `foo({ displayName: 'NAME' });` => 'NAME'
-      const componentName = getDisplayName(path.node).replace(/[\.-]/g, '_'); //Make sure all non-JSON accepted characters are replaced!
+      const displayName = getDisplayName(path.node);
+      const componentName = displayName ? displayName.replace(/[\.-]/g, '_') : undefined; //Make sure all non-JSON accepted characters are replaced!
       const componentId = componentName || path.scope.generateUid('component');
       const isInFunction = hasParentFunction(path);
 


### PR DESCRIPTION
When you use '.' or '-' in your displayname, the transformer crashes as it tries to use this name for a wrapping object.
I've replaced '.' and '-' but I guess more characters need to be checked to make this foolproof.