### PR TITLE
try get display name only if the component spec is a ObjectExpression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,17 @@ export default function({ types: t, template }) {
   }
 
   // `foo({ displayName: 'NAME' });` => 'NAME'
+  // only handle the case when spec is an ObjectExpression
   function getDisplayName(node) {
-    const property = find(node.arguments[0].properties, node => node.key.name === 'displayName');
+    const spec = node.arguments[0];
+
+    if (spec.type !== 'ObjectExpression') {
+      return;
+    }
+
+    const property = find(spec.properties, node => (
+      node.type === 'ObjectProperty' && node.key.name === 'displayName'
+    ));
     return property && property.value.value;
   }
 

--- a/test/fixtures/code-react-create-class-with-call-expression/.babelrc
+++ b/test/fixtures/code-react-create-class-with-call-expression/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "transforms": [{
+        "transform": "transform-lib"
+      }]
+    }]
+  ]
+}

--- a/test/fixtures/code-react-create-class-with-call-expression/actual.js
+++ b/test/fixtures/code-react-create-class-with-call-expression/actual.js
@@ -1,0 +1,9 @@
+const myCreateClass = (spec) => {
+  const propTypes = Object.assign({
+    model: React.PropTypes.object.isRequired
+  }, spec.propTypes);
+
+  const updatedSpec = Object.assign({}, spec, { propTypes });
+
+  return React.createClass(updatedSpec);
+};

--- a/test/fixtures/code-react-create-class-with-call-expression/expected.js
+++ b/test/fixtures/code-react-create-class-with-call-expression/expected.js
@@ -1,0 +1,29 @@
+import _transformLib from "transform-lib";
+const _components = {
+  _component: {
+    isInFunction: true
+  }
+};
+
+const _transformLib2 = _transformLib({
+  filename: "%FIXTURE_PATH%",
+  components: _components,
+  locals: [],
+  imports: []
+});
+
+function _wrapComponent(id) {
+  return function (Component) {
+    return _transformLib2(Component, id);
+  };
+}
+
+const myCreateClass = spec => {
+  const propTypes = Object.assign({
+    model: React.PropTypes.object.isRequired
+  }, spec.propTypes);
+
+  const updatedSpec = Object.assign({}, spec, { propTypes });
+
+  return _wrapComponent("_component")(React.createClass(updatedSpec));
+};


### PR DESCRIPTION
There're cases when the parameter passed to React.createClass is dynamic and could possibly be an __expression__, for example this case:

```javascript
const myCreateClass = (spec) => {
  const propTypes = Object.assign({
    model: React.PropTypes.object.isRequired
  }, spec.propTypes);

  const updatedSpec = Object.assign({}, spec, { propTypes });

  return React.createClass(updatedSpec);
};
```

Today the react-transform will crash simply due to some strong assumption in the *getDisplayName* method which is not very reasonable.

This pull request add some conditional judgement to getDisplayName method to make it more robust and do not crash when meeting some special node types.

solves #61 Display name cannot be resolved in all cases