### PR TITLE
Added support for `createClass` by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ export default function({ types: t, template }) {
 
     normalizeOptions(options) {
       return {
-        factoryMethods: options.factoryMethods || ['React.createClass'],
+        factoryMethods: options.factoryMethods || ['React.createClass', 'createClass'],
         superClasses: options.superClasses || ['React.Component', 'Component'],
         transforms: options.transforms.map(opts => {
           return {

--- a/test/fixtures/code-react-create-class-factory-with-render-method/.babelrc
+++ b/test/fixtures/code-react-create-class-factory-with-render-method/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "transforms": [{
+        "transform": "transform-lib"
+      }]
+    }]
+  ]
+}

--- a/test/fixtures/code-react-create-class-factory-with-render-method/actual.js
+++ b/test/fixtures/code-react-create-class-factory-with-render-method/actual.js
@@ -1,0 +1,15 @@
+import { createClass } from 'react';
+
+
+const Foo = createClass({
+  displayName: 'Foo',
+  render: function () {}
+});
+
+createClass({
+  render: function () {}
+});
+
+const Bar = createClass({
+  render: function () {}
+});

--- a/test/fixtures/code-react-create-class-factory-with-render-method/expected.js
+++ b/test/fixtures/code-react-create-class-factory-with-render-method/expected.js
@@ -1,0 +1,36 @@
+import _transformLib from 'transform-lib';
+const _components = {
+  Foo: {
+    displayName: 'Foo'
+  },
+  _component: {},
+  _component2: {}
+};
+
+const _transformLib2 = _transformLib({
+  filename: '%FIXTURE_PATH%',
+  components: _components,
+  locals: [],
+  imports: []
+});
+
+function _wrapComponent(id) {
+  return function (Component) {
+    return _transformLib2(Component, id);
+  };
+}
+
+import { createClass } from 'react';
+
+const Foo = _wrapComponent('Foo')(createClass({
+  displayName: 'Foo',
+  render: function () {}
+}));
+
+_wrapComponent('_component')(createClass({
+  render: function () {}
+}));
+
+const Bar = _wrapComponent('_component2')(createClass({
+  render: function () {}
+}));


### PR DESCRIPTION
Currently the support for react component creation exists only for `React.createClass`, `extends Component`, and `extends React.Component`. This pull request adds support by default for just `createClass` when used in a destructured import environment.

I am aware that this is supported via options, but when consuming this plugin via `react-hmre` as the current transform boilerplate does this isn't possible. I opened this issue https://github.com/danmartinez101/babel-preset-react-hmre/issues/24, and the response was that it'd be better to enhance at the source.

Also, it seems logical to support both destructured formats: `Component` and `createClass`, not just one of them. Was this an active decision?