### PR TITLE
Add link to react-transform-count-renders and react-transform-log-render

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For a starter kit to help write your own transforms, see [**react-transform-noop
 * [**react-transform-debug-inspector**](https://github.com/alexkuz/react-transform-debug-inspector) - renders an inline prop inspector
 * [**react-transform-render-visualizer**](https://github.com/spredfast/react-transform-render-visualizer) - highlight components when updated
 * [**react-transform-style**](https://github.com/pwmckenna/react-transform-style) - support `style` and `className` styling for all components
+* [**react-transform-count-renders**](https://github.com/stipsan/react-transform-count-renders) - counts how many times your components render
 
 Feeling inspired? Learn [how to write transforms](#writing-transforms) and send a PR!
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For a starter kit to help write your own transforms, see [**react-transform-noop
 * [**react-transform-debug-inspector**](https://github.com/alexkuz/react-transform-debug-inspector) - renders an inline prop inspector
 * [**react-transform-render-visualizer**](https://github.com/spredfast/react-transform-render-visualizer) - highlight components when updated
 * [**react-transform-style**](https://github.com/pwmckenna/react-transform-style) - support `style` and `className` styling for all components
+* [**react-transform-log-render**](https://github.com/rkit/react-transform-log-render) - log component renders with passed props and state
 * [**react-transform-count-renders**](https://github.com/stipsan/react-transform-count-renders) - counts how many times your components render
 
 Feeling inspired? Learn [how to write transforms](#writing-transforms) and send a PR!


### PR DESCRIPTION
Hey, thought others might be interested in this.
Up til now I've added `console.count` calls to my render methods by hand when I'm suspecting a performance bottleneck but can't be bothered to wire up the Perf tools.
I got sick of that and did what any lazy developer would do, **automate** it 😁

Edit: 
I discovered another plugin that's pretty similar but logs passed props and state and wraps the renders in `console.group`, very nice. Updated the PR with a link to that plugin while at it.