### PR TITLE
Guard access to node.key when finding displayName

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default function({ types: t, template }) {
 
   // `foo({ displayName: 'NAME' });` => 'NAME'
   function getDisplayName(node) {
-    const property = find(node.arguments[0].properties, node => node.key.name === 'displayName');
+    const property = find(node.arguments[0].properties, node => node.type === 'ObjectProperty' && node.key.name === 'displayName');
     return property && property.value.value;
   }
 


### PR DESCRIPTION
This PR addresses an issue where use of the spread operator inside of a component spec causes `getDisplayName` to fail, since `SpreadOperator` nodes don't have a `key` property.

Example class:
```js
const definition = {};
React.createClass({
  ...definition,
  displayName: 'TestClass',
});
```
Error output:
```
TypeError: Cannot read property 'name' of undefined while parsing file: <file>
```
