### PR TITLE
Adding "React.PureComponent" to list of base classes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ export default function({ types: t, template }) {
     normalizeOptions(options) {
       return {
         factoryMethods: options.factoryMethods || ['React.createClass'],
-        superClasses: options.superClasses || ['React.Component', 'Component'],
+        superClasses: options.superClasses || ['React.Component', 'React.PureComponent', 'Component'],
         transforms: options.transforms.map(opts => {
           return {
             transform: opts.transform,


### PR DESCRIPTION
This will fix all the issues related to "PureComponents" not being transformed/hot-reloaded