### PR TITLE
Generate {hot: module.hot} for a 'module' local

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,6 +284,12 @@ export default function({ types: t, template }) {
         const transformImportId = this.file.addImport(transformName, 'default', transformName);
 
         const transformLocals = transform.locals.map(local => {
+          // Webpack 2 disallows use of a bare 'module' identifier in ES2015 modules
+          if (local === 'module') {
+            return toObjectExpression({
+              hot: t.memberExpression(t.identifier('module'), t.identifier('hot'))
+            });
+          }
           return t.identifier(local);
         });
 

--- a/test/fixtures/options-with-locals-with-render-method/expected.js
+++ b/test/fixtures/options-with-locals-with-render-method/expected.js
@@ -8,7 +8,9 @@ const _components = {
 const _transformLib2 = _transformLib({
   filename: "%FIXTURE_PATH%",
   components: _components,
-  locals: [module, exports],
+  locals: [{
+    hot: module.hot
+  }, exports],
   imports: []
 });
 


### PR DESCRIPTION
As of RC4, Webpack 2 disallows use of a bare `module` identifier in ES2015 modules.

This fixes the following error with the common React HMRE setup when your components are ES2015 module syntax:

`module is not allowed in EcmaScript module: This module was detected as EcmaScript module (import or export syntax was used). In such a module using 'module' is not allowed.`

Are there any existing transforms which use `module` properties other than `hot`?

---

See https://github.com/webpack/webpack/issues/3917 for discussion on the Webpack side of things.