### PR TITLE
Add React.PureComponent to the list of default super classes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ export default function({ types: t, template }) {
     normalizeOptions(options) {
       return {
         factoryMethods: options.factoryMethods || ['React.createClass'],
-        superClasses: options.superClasses || ['React.Component', 'Component'],
+        superClasses: options.superClasses || ['React.Component', 'React.PureComponent', 'Component', 'PureComponent'],
         transforms: options.transforms.map(opts => {
           return {
             transform: opts.transform,

--- a/test/fixtures/code-class-extends-purecomponent-with-render-method/.babelrc
+++ b/test/fixtures/code-class-extends-purecomponent-with-render-method/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "transforms": [{
+        "transform": "transform-lib"
+      }]
+    }]
+  ]
+}

--- a/test/fixtures/code-class-extends-purecomponent-with-render-method/actual.js
+++ b/test/fixtures/code-class-extends-purecomponent-with-render-method/actual.js
@@ -1,0 +1,4 @@
+import React, { PureComponent } from 'react';
+class Foo extends PureComponent {
+  render() {}
+}

--- a/test/fixtures/code-class-extends-purecomponent-with-render-method/expected.js
+++ b/test/fixtures/code-class-extends-purecomponent-with-render-method/expected.js
@@ -1,0 +1,25 @@
+import _transformLib from 'transform-lib';
+const _components = {
+  Foo: {
+    displayName: 'Foo'
+  }
+};
+
+const _transformLib2 = _transformLib({
+  filename: '%FIXTURE_PATH%',
+  components: _components,
+  locals: [],
+  imports: []
+});
+
+function _wrapComponent(id) {
+  return function (Component) {
+    return _transformLib2(Component, id);
+  };
+}
+
+import React, { PureComponent } from 'react';
+
+const Foo = _wrapComponent('Foo')(class Foo extends PureComponent {
+  render() {}
+});

--- a/test/fixtures/code-exports/actual.js
+++ b/test/fixtures/code-exports/actual.js
@@ -1,8 +1,6 @@
-export default class Foo extends React.Component {}
-export default class extends React.Component {}
+export class Foo extends React.Component {}
 export default React.createClass({});
 export class Bar extends React.Component {}
 export const bar = React.createClass({});
-export default class Baz { render() {} }
-export default class { render() {} }
+export class Baz { render() {} }
 export class Boo { render() {} }

--- a/test/fixtures/code-exports/expected.js
+++ b/test/fixtures/code-exports/expected.js
@@ -1,12 +1,8 @@
-export default class Foo extends React.Component {}
-export default class extends React.Component {}
+export class Foo extends React.Component {}
 export default React.createClass({});
 export class Bar extends React.Component {}
 export const bar = React.createClass({});
-export default class Baz {
-  render() {}
-}
-export default class {
+export class Baz {
   render() {}
 }
 export class Boo {


### PR DESCRIPTION
This PR enables the HMR transform to work on components that extend `React.PureComponent`